### PR TITLE
Fix percentile inputs given for height attribute

### DIFF
--- a/src/twitch-stream.js
+++ b/src/twitch-stream.js
@@ -172,7 +172,7 @@ export default class TwitchStream extends HTMLElement {
 
     static get template() {
         const template = document.createElement('template');
-        template.innerHTML = `<div id="twitch-embed"></div>`;
+        template.innerHTML = `<div id="twitch-embed" style="height: 100%"></div>`;
         return template;
     }
 


### PR DESCRIPTION
The wrapping `twitch-embed` element is currently defaulted to `auto` height so a percentile height on child elements is ineffective, making percentile input on the components `height` attribute also ineffective.